### PR TITLE
TMS-978: Remove automatic line breaks from event description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+## [1.0.3] - 2023-10-04
+
 - TMS-978: Add classes to single manual-event description
 
 ## [1.0.2] - 2023-08-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+- TMS-978: Add classes to single manual-event description
+
 ## [1.0.2] - 2023-08-30
 
 - TMS-964: Use new Eventz api.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+## [1.0.5] - 2023-10-09
+
 - TMS-978: Remove automatic line breaks from event description
 
 ## [1.0.3] - 2023-10-04

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+- TMS-978: Remove automatic line breaks from event description
+
 ## [1.0.3] - 2023-10-04
 
 - TMS-978: Add classes to single manual-event description

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: TMS Manual Events
  * Plugin URI: https://github.com/devgeniem/tms-plugin-manual-events
  * Description: TMS Manual Events
- * Version: 1.0.1
+ * Version: 1.0.3
  * Requires PHP: 7.4
  * Author: Geniem Oy
  * Author URI: https://geniem.com

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: TMS Manual Events
  * Plugin URI: https://github.com/devgeniem/tms-plugin-manual-events
  * Description: TMS Manual Events
- * Version: 1.0.3
+ * Version: 1.0.5
  * Requires PHP: 7.4
  * Author: Geniem Oy
  * Author URI: https://geniem.com

--- a/src/Partials/single-manual-event-cpt.dust
+++ b/src/Partials/single-manual-event-cpt.dust
@@ -48,7 +48,7 @@
                                 {/event.normalized.short_description}
 
                                 <div class="columns is-multiline is-variable is-8 mb-8">
-                                    <div class="entry__description column is-5-desktop is-offset-1-desktop keep-vertical-spacing has-line-height-normal">
+                                    <div class="entry__description column is-5-desktop is-offset-1-desktop keep-vertical-spacing">
                                         {event.normalized.description|kses}
                                     </div>
 

--- a/src/Partials/single-manual-event-cpt.dust
+++ b/src/Partials/single-manual-event-cpt.dust
@@ -48,7 +48,7 @@
                                 {/event.normalized.short_description}
 
                                 <div class="columns is-multiline is-variable is-8 mb-8">
-                                    <div class="column is-5-desktop is-offset-1-desktop keep-vertical-spacing">
+                                    <div class="entry__description column is-5-desktop is-offset-1-desktop keep-vertical-spacing has-line-height-normal">
                                         {event.normalized.description|kses}
                                     </div>
 

--- a/src/PostType/ManualEvent.php
+++ b/src/PostType/ManualEvent.php
@@ -467,7 +467,7 @@ class ManualEvent {
         $normalized_event = [
             'name'               => $event->title ?? '',
             'short_description'  => $event->short_description ?? '',
-            'description'        => nl2br( $event->description ?? '' ),
+            'description'        => $event->description ?? '',
             'date'               => static::get_event_date( $event ),
             'time'               => static::get_event_time( $event ),
             // Include raw dates for possible sorting.


### PR DESCRIPTION
Task: https://hiondigital.atlassian.net/browse/TMS-978

Remove automatic line breaks from event description, since the WYSIWYG editor places line-breaks automatically