### PR TITLE
TMS-968: Add recurring event fields to manual events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,9 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
-- TMS-968: Add recurring event fields to manual events
+- TMS-968:
+    - Add recurring event fields to manual events
+    - Add recurring event logic to events component, combined event search & combined event listing
 
 ## [1.2.0] - 2024-02-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+- TMS-968: Add recurring event fields to manual events
+
 ## [1.2.0] - 2024-02-01
 
 - TMS-977: Add combined events search page-template.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+## [1.3.0] - 2024-03-26
+
 - TMS-968:
     - Add recurring event fields to manual events
     - Add recurring event logic to events component, combined event search & combined event listing

--- a/plugin.php
+++ b/plugin.php
@@ -3,7 +3,7 @@
  * Plugin Name: TMS Manual Events
  * Plugin URI: https://github.com/devgeniem/tms-plugin-manual-events
  * Description: TMS Manual Events
- * Version: 1.2.0
+ * Version: 1.3.0
  * Requires PHP: 7.4
  * Author: Geniem Oy
  * Author URI: https://geniem.com

--- a/src/Models/page-combined-events-list.php
+++ b/src/Models/page-combined-events-list.php
@@ -99,7 +99,11 @@ class PageCombinedEventsList extends PageEventsSearch {
 
         if ( empty( $response ) ) {
             $response           = $this->do_get_events( $params );
-            $response['events'] = array_merge( $response['events'], $this->get_manual_events(), $this->get_recurring_manual_events() );
+            $response['events'] = array_merge(
+                $response['events'],
+                $this->get_manual_events(),
+                $this->get_recurring_manual_events()
+            );
 
             // Sort events by start datetime objects.
             usort( $response['events'], function( $a, $b ) {
@@ -206,7 +210,7 @@ class PageCombinedEventsList extends PageEventsSearch {
                     $event->id             = $id;
                     $event->title          = \get_the_title( $id );
                     $event->url            = \get_permalink( $id );
-                    $event->image          = \has_post_thumbnail( $id ) ? \get_the_post_thumbnail_url( $id, 'medium_large' ) : null;
+                    $event->image          = \has_post_thumbnail( $id ) ? \get_the_post_thumbnail_url( $id, 'medium_large' ) : null; // phpcs:ignore
                     $event->start_datetime = $date['start'];
                     $event->end_datetime   = $date['end'];
 

--- a/src/Models/page-combined-events-list.php
+++ b/src/Models/page-combined-events-list.php
@@ -193,13 +193,14 @@ class PageCombinedEventsList extends PageEventsSearch {
 
         // Loop through events
         $recurring_events = array_map( function ( $e ) {
-            $id    = $e->ID;
-            $event = (object) \get_fields( $id );
+            $id       = $e->ID;
+            $event    = (object) \get_fields( $id );
+            $time_now = \current_datetime();
+            $timezone = new DateTimeZone( 'Europe/Helsinki' );
 
             foreach ( $event->dates as $date ) {
-                $time_now    = \current_datetime()->getTimestamp();
-                $event_start = strtotime( $date['start'] );
-                $event_end   = strtotime( $date['end'] );
+                $event_start = new DateTime( $date['start'], $timezone );
+                $event_end   = new DateTime( $date['end'], $timezone );
 
                 // Return only ongoing or next upcoming event
                 if ( ( $time_now > $event_start && $time_now < $event_end ) || $time_now < $event_start ) {

--- a/src/Models/page-combined-events-list.php
+++ b/src/Models/page-combined-events-list.php
@@ -216,6 +216,6 @@ class PageCombinedEventsList extends PageEventsSearch {
             }
         }, $query->posts );
 
-        return $recurring_events;
+        return array_filter( $recurring_events );
     }
 }

--- a/src/Models/page-combined-events-list.php
+++ b/src/Models/page-combined-events-list.php
@@ -179,8 +179,8 @@ class PageCombinedEventsList extends PageEventsSearch {
             'posts_per_page' => 200, // phpcs:ignore
             'meta_query'     => [
                 [
-                    'key'     => 'recurring_event',
-                    'value'   => 1,
+                    'key'   => 'recurring_event',
+                    'value' => 1,
                 ],
             ],
         ];
@@ -197,7 +197,6 @@ class PageCombinedEventsList extends PageEventsSearch {
             $event = (object) \get_fields( $id );
 
             foreach ( $event->dates as $date ) {
-                date_default_timezone_set( 'Europe/Helsinki' );
                 $time_now    = \current_datetime()->getTimestamp();
                 $event_start = strtotime( $date['start'] );
                 $event_end   = strtotime( $date['end'] );

--- a/src/Models/page-combined-events-list.php
+++ b/src/Models/page-combined-events-list.php
@@ -141,9 +141,8 @@ class PageCombinedEventsList extends PageEventsSearch {
                     'type'    => 'DATE',
                 ],
                 [
-                    'key'     => 'end_datetime',
-                    'value'   => '',
-                    'compare' => '!=',
+                    'key'   => 'recurring_event',
+                    'value' => 0,
                 ],
             ],
         ];

--- a/src/Models/page-combined-events-search.php
+++ b/src/Models/page-combined-events-search.php
@@ -246,6 +246,8 @@ class PageCombinedEventsSearch extends PageEventsSearch {
     /**
      * Get recurring manual events.
      *
+     * @param array $params Query parameters.
+     *
      * @return array
      */
     protected function get_recurring_manual_events( $params ) : array {
@@ -255,8 +257,8 @@ class PageCombinedEventsSearch extends PageEventsSearch {
             's'              => $params['q'] ?? '',
             'meta_query'     => [
                 [
-                    'key'     => 'recurring_event',
-                    'value'   => 1,
+                    'key'   => 'recurring_event',
+                    'value' => 1,
                 ],
             ],
         ];
@@ -269,15 +271,14 @@ class PageCombinedEventsSearch extends PageEventsSearch {
 
         // Loop through events
         $recurring_events = array_map( function ( $e ) use ( $params ) {
-            $id    = $e->ID;
-            $event = (object) \get_fields( $id );
+            $id           = $e->ID;
+            $event        = (object) \get_fields( $id );
             $event->id    = $id;
             $event->title = \get_the_title( $id );
             $event->url   = \get_permalink( $id );
             $event->image = \has_post_thumbnail( $id ) ? \get_the_post_thumbnail_url( $id, 'medium_large' ) : null;
 
             foreach ( $event->dates as $date ) {
-                date_default_timezone_set( 'Europe/Helsinki' );
                 $time_now     = \current_datetime()->getTimestamp();
                 $event_start  = strtotime( $date['start'] );
                 $event_end    = strtotime( $date['end'] );

--- a/src/Models/page-combined-events-search.php
+++ b/src/Models/page-combined-events-search.php
@@ -115,7 +115,7 @@ class PageCombinedEventsSearch extends PageEventsSearch {
         $end_date = \get_query_var( self::EVENT_SEARCH_END_DATE );
         $end_date = ! empty( $end_date ) ? $end_date : date( 'Y-m-d', strtotime( '+1 year' ) );
 
-        if ( ! $event_search_text && ! \get_query_var( self::EVENT_SEARCH_START_DATE ) && ! \get_query_var( self::EVENT_SEARCH_END_DATE ) ) {
+        if ( ! $event_search_text && ! \get_query_var( self::EVENT_SEARCH_START_DATE ) && ! \get_query_var( self::EVENT_SEARCH_END_DATE ) ) { // phpcs:ignore
             return [];
         }
 
@@ -151,7 +151,11 @@ class PageCombinedEventsSearch extends PageEventsSearch {
 
         if ( empty( $response ) ) {
             $response           = $this->do_get_events( $params );
-            $response['events'] = array_merge( $response['events'] ?? [], $this->get_manual_events( $params ), $this->get_recurring_manual_events( $params ) );
+            $response['events'] = array_merge(
+                $response['events'] ?? [],
+                $this->get_manual_events( $params ),
+                $this->get_recurring_manual_events( $params )
+            );
 
             // Sort events by start datetime objects.
             usort( $response['events'], function( $a, $b ) {
@@ -284,15 +288,18 @@ class PageCombinedEventsSearch extends PageEventsSearch {
                 $event_end   = new DateTime( $date['end'], $timezone );
 
                 // Check if url-parameters exist
-                if ( ! \get_query_var( self::EVENT_SEARCH_START_DATE ) && ! \get_query_var( self::EVENT_SEARCH_END_DATE ) ) {
+                if ( ! \get_query_var( self::EVENT_SEARCH_START_DATE ) && ! \get_query_var( self::EVENT_SEARCH_END_DATE ) ) { // phpcs:ignore
                     // Return only ongoing or next upcoming event
                     if ( $time_now > $event_start && $time_now < $event_end ) {
                         $event->start_datetime = $date['start'];
                         $event->end_datetime   = $date['end'];
                     }
                 }
-                else if ( \get_query_var( self::EVENT_SEARCH_START_DATE ) ) {
-                    $param_start = new DateTime( \get_query_var( self::EVENT_SEARCH_START_DATE ), new \DateTimeZone( 'Europe/Helsinki' ) );
+                elseif ( \get_query_var( self::EVENT_SEARCH_START_DATE ) ) {
+                    $param_start = new DateTime(
+                        \get_query_var( self::EVENT_SEARCH_START_DATE ),
+                        new \DateTimeZone( 'Europe/Helsinki' )
+                    );
 
                     // Get next starting event
                     if ( $param_start <= $event_start ) {

--- a/src/Models/page-combined-events-search.php
+++ b/src/Models/page-combined-events-search.php
@@ -249,12 +249,6 @@ class PageCombinedEventsSearch extends PageEventsSearch {
      * @return array
      */
     protected function get_recurring_manual_events( $params ) : array {
-        /**
-         * TODO:
-         * Logiikka tässä siten, että ensimmäisenä tarkistetaan meneillään oleva päivä repeaterista (?)
-         * Kun meneillään oleva aikaväli on tiedossa, voidaan suodattaa kyseiset päivämäärät parametrien avulla
-         * ^^ Tähän ei välttämättä tarvii edes queryssä tehdä tuota logiikkaa
-         */
         $args = [
             'post_type'      => PostType\ManualEvent::SLUG,
             'posts_per_page' => 200, // phpcs:ignore

--- a/src/Models/page-combined-events-search.php
+++ b/src/Models/page-combined-events-search.php
@@ -184,6 +184,7 @@ class PageCombinedEventsSearch extends PageEventsSearch {
             'posts_per_page' => 200, // phpcs:ignore
             's'              => $params['q'] ?? '',
             'meta_query'     => [
+                'relation' => 'AND',
                 [
                     'key'     => 'end_datetime',
                     'value'   => [
@@ -192,6 +193,10 @@ class PageCombinedEventsSearch extends PageEventsSearch {
                     ],
                     'compare' => 'BETWEEN',
                     'type'    => 'DATE',
+                ],
+                [
+                    'key'   => 'recurring_event',
+                    'value' => 0,
                 ],
             ],
         ];

--- a/src/Models/page-combined-events-search.php
+++ b/src/Models/page-combined-events-search.php
@@ -184,7 +184,6 @@ class PageCombinedEventsSearch extends PageEventsSearch {
             'posts_per_page' => 200, // phpcs:ignore
             's'              => $params['q'] ?? '',
             'meta_query'     => [
-                'relation' => 'AND',
                 [
                     'key'     => 'end_datetime',
                     'value'   => [
@@ -193,11 +192,6 @@ class PageCombinedEventsSearch extends PageEventsSearch {
                     ],
                     'compare' => 'BETWEEN',
                     'type'    => 'DATE',
-                ],
-                [
-                    'key'     => 'end_datetime',
-                    'value'   => '',
-                    'compare' => '!=',
                 ],
             ],
         ];

--- a/src/Models/page-combined-events-search.php
+++ b/src/Models/page-combined-events-search.php
@@ -277,11 +277,12 @@ class PageCombinedEventsSearch extends PageEventsSearch {
             $event->title = \get_the_title( $id );
             $event->url   = \get_permalink( $id );
             $event->image = \has_post_thumbnail( $id ) ? \get_the_post_thumbnail_url( $id, 'medium_large' ) : null;
+            $timezone     = new DateTimeZone( 'Europe/Helsinki' );
+            $time_now     = new DateTime( 'now', $timezone );
 
             foreach ( $event->dates as $date ) {
-                $time_now     = \current_datetime()->getTimestamp();
-                $event_start  = strtotime( $date['start'] );
-                $event_end    = strtotime( $date['end'] );
+                $event_start = new DateTime( $date['start'], $timezone );
+                $event_end   = new DateTime( $date['end'], $timezone );
 
                 // Check if url-parameters exist
                 if ( ! \get_query_var( self::EVENT_SEARCH_START_DATE ) && ! \get_query_var( self::EVENT_SEARCH_END_DATE ) ) {
@@ -291,8 +292,9 @@ class PageCombinedEventsSearch extends PageEventsSearch {
                         $event->end_datetime   = $date['end'];
                     }
                 }
-                else {
-                    $param_start = strtotime( \get_query_var( self::EVENT_SEARCH_START_DATE ) );
+                else if ( \get_query_var( self::EVENT_SEARCH_START_DATE ) ) {
+                    $param_start = new DateTime( \get_query_var( self::EVENT_SEARCH_START_DATE ), new \DateTimeZone( 'Europe/Helsinki' ) );
+
                     // Get next starting event
                     if ( $param_start <= $event_start ) {
                         $event->start_datetime = $date['start'];

--- a/src/Models/single-manual-event-cpt.php
+++ b/src/Models/single-manual-event-cpt.php
@@ -105,7 +105,6 @@ class SingleManualEventCpt extends PageEvent {
         // Change dates if recurring event
         if ( $event->recurring_event ) {
             foreach ( $event->dates as $date ) {
-                date_default_timezone_set( 'Europe/Helsinki' );
                 $time_now    = \current_datetime()->getTimestamp();
                 $event_start = strtotime( $date['start'] );
                 $event_end   = strtotime( $date['end'] );

--- a/src/Models/single-manual-event-cpt.php
+++ b/src/Models/single-manual-event-cpt.php
@@ -102,6 +102,23 @@ class SingleManualEventCpt extends PageEvent {
             return null;
         }
 
+        // Change dates if recurring event
+        if ( $event->recurring_event ) {
+            foreach ( $event->dates as $date ) {
+                date_default_timezone_set( 'Europe/Helsinki' );
+                $time_now    = \current_datetime()->getTimestamp();
+                $event_start = strtotime( $date['start'] );
+                $event_end   = strtotime( $date['end'] );
+
+                // Return only ongoing or next upcoming event
+                if ( ( $time_now > $event_start && $time_now < $event_end ) || $time_now < $event_start ) {
+                    $event->start_datetime = $date['start'];
+                    $event->end_datetime   = $date['end'];
+                    break;
+                }
+            }
+        }
+
         return [
             'normalized' => ManualEvent::normalize_event( $event ),
             'orig'       => $event,

--- a/src/Models/single-manual-event-cpt.php
+++ b/src/Models/single-manual-event-cpt.php
@@ -121,7 +121,7 @@ class SingleManualEventCpt extends PageEvent {
 
             // Set latest dates if no upcoming date found
             if ( empty( $event->start_datetime ) && empty( $event->end_datetime ) ) {
-                $last_dates = end( $event->dates );
+                $last_dates            = end( $event->dates );
                 $event->start_datetime = $last_dates['start'];
                 $event->end_datetime   = $last_dates['end'];
             }

--- a/src/Models/single-manual-event-cpt.php
+++ b/src/Models/single-manual-event-cpt.php
@@ -117,6 +117,13 @@ class SingleManualEventCpt extends PageEvent {
                     break;
                 }
             }
+
+            // Set latest dates if no upcoming date found
+            if ( empty( $event->start_datetime ) && empty( $event->end_datetime ) ) {
+                $last_dates = end( $event->dates );
+                $event->start_datetime = $last_dates['start'];
+                $event->end_datetime   = $last_dates['end'];
+            }
         }
 
         return [

--- a/src/Models/single-manual-event-cpt.php
+++ b/src/Models/single-manual-event-cpt.php
@@ -104,10 +104,12 @@ class SingleManualEventCpt extends PageEvent {
 
         // Change dates if recurring event
         if ( $event->recurring_event ) {
+            $time_now = \current_datetime();
+            $timezone = new DateTimeZone( 'Europe/Helsinki' );
+
             foreach ( $event->dates as $date ) {
-                $time_now    = \current_datetime()->getTimestamp();
-                $event_start = strtotime( $date['start'] );
-                $event_end   = strtotime( $date['end'] );
+                $event_start = new DateTime( $date['start'], $timezone );
+                $event_end   = new DateTime( $date['end'], $timezone );
 
                 // Return only ongoing or next upcoming event
                 if ( ( $time_now > $event_start && $time_now < $event_end ) || $time_now < $event_start ) {

--- a/src/PostType/ManualEvent.php
+++ b/src/PostType/ManualEvent.php
@@ -465,20 +465,24 @@ class ManualEvent {
                 ->add_rule( $price_is_free->get_key(), '!=', '1' );
             $rule_group_is_virtual_event = ( new ConditionalLogicGroup() )
                 ->add_rule( $is_virtual_event->get_key(), '==', '1' );
+            $rule_group_is_not_recurring     = ( new ConditionalLogicGroup() )
+                ->add_rule( $recurring_event->get_key(), '==', '0' );
             $rule_group_is_recurring     = ( new ConditionalLogicGroup() )
                 ->add_rule( $recurring_event->get_key(), '==', '1' );
 
             $price_group->add_conditional_logic( $rule_group_has_price );
             $virtual_event_link->add_conditional_logic( $rule_group_is_virtual_event );
+            $start_datetime->add_conditional_logic( $rule_group_is_not_recurring );
+            $end_datetime->add_conditional_logic( $rule_group_is_not_recurring );
             $recurring_dates->add_conditional_logic( $rule_group_is_recurring );
             $recurring_dates->add_fields( [ $recurring_start_datetime, $recurring_end_datetime ] );
 
             $tab->add_fields( [
                 $description,
                 $short_description,
+                $recurring_event,
                 $start_datetime,
                 $end_datetime,
-                $recurring_event,
                 $recurring_dates,
                 $location_group,
                 $price_is_free,
@@ -523,7 +527,7 @@ class ManualEvent {
             'location_title'     => __( 'Location', 'tms-theme-base' ),
             'price_title'        => __( 'Price', 'tms-theme-base' ),
             'provider_title'     => __( 'Organizer', 'tms-theme-base' ),
-            'recurring'          => isset( $event->dates ) ? count( $event->dates ) > 1 : null,
+            'recurring'          => ! empty( $event->dates ) ? count( $event->dates ) > 1 : null,
             'dates'              => static::get_event_dates( $event ),
         ];
 

--- a/src/PostType/ManualEvent.php
+++ b/src/PostType/ManualEvent.php
@@ -220,6 +220,15 @@ class ManualEvent {
                 'label'        => 'Päättymisajankohta',
                 'instructions' => '',
             ],
+            'recurring_event'    => [
+                'label'        => 'Toistuva tapahtuma',
+                'instructions' => '',
+            ],
+            'recurring_dates'    => [
+                'label'        => 'Toistuvan tapahtuman ajankohdat',
+                'button_label' => 'Lisää ajankohta',
+                'instructions' => '',
+            ],
             'location'           => [
                 'label'       => 'Sijainti',
                 'name'        => [
@@ -319,6 +328,32 @@ class ManualEvent {
                 ->set_display_format( 'j.n.Y H:i' )
                 ->set_return_format( 'Y-m-d H:i:s' )
                 ->redipress_add_queryable( 'end_datetime' );
+
+            $recurring_event = ( new Field\TrueFalse( $strings['recurring_event']['label'] ) )
+                ->set_key( "{$key}_recurring_event" )
+                ->set_name( 'recurring_event' )
+                ->set_instructions( $strings['recurring_event']['instructions'] )
+                ->use_ui();
+
+            $recurring_dates = ( new Field\Repeater( $strings['recurring_dates']['label'] ) )
+                ->set_key( "{$key}_dates" )
+                ->set_name( 'dates' )
+                ->set_instructions( $strings['recurring_dates']['instructions'] )
+                ->set_button_label( $strings['recurring_dates']['button_label'] );
+
+            $recurring_start_datetime = ( new Field\DateTimePicker( $strings['start_datetime']['label'] ) )
+                ->set_key( "{$key}_start" )
+                ->set_name( 'start' )
+                ->set_instructions( $strings['start_datetime']['instructions'] )
+                ->set_display_format( 'j.n.Y H:i' )
+                ->set_return_format( 'Y-m-d H:i:s' );
+
+            $recurring_end_datetime = ( new Field\DateTimePicker( $strings['end_datetime']['label'] ) )
+                ->set_key( "{$key}_end" )
+                ->set_name( 'end' )
+                ->set_instructions( $strings['end_datetime']['instructions'] )
+                ->set_display_format( 'j.n.Y H:i' )
+                ->set_return_format( 'Y-m-d H:i:s' );
 
             $location_name = ( new Field\Text( $strings['location']['name']['label'] ) )
                 ->set_key( "{$key}_location_name" )
@@ -430,15 +465,21 @@ class ManualEvent {
                 ->add_rule( $price_is_free->get_key(), '!=', '1' );
             $rule_group_is_virtual_event = ( new ConditionalLogicGroup() )
                 ->add_rule( $is_virtual_event->get_key(), '==', '1' );
+            $rule_group_is_recurring     = ( new ConditionalLogicGroup() )
+                ->add_rule( $recurring_event->get_key(), '==', '1' );
 
             $price_group->add_conditional_logic( $rule_group_has_price );
             $virtual_event_link->add_conditional_logic( $rule_group_is_virtual_event );
+            $recurring_dates->add_conditional_logic( $rule_group_is_recurring );
+            $recurring_dates->add_fields( [ $recurring_start_datetime, $recurring_end_datetime ] );
 
             $tab->add_fields( [
                 $description,
                 $short_description,
                 $start_datetime,
                 $end_datetime,
+                $recurring_event,
+                $recurring_dates,
                 $location_group,
                 $price_is_free,
                 $price_group,
@@ -482,6 +523,8 @@ class ManualEvent {
             'location_title'     => __( 'Location', 'tms-theme-base' ),
             'price_title'        => __( 'Price', 'tms-theme-base' ),
             'provider_title'     => __( 'Organizer', 'tms-theme-base' ),
+            'recurring'          => isset( $event->dates ) ? count( $event->dates ) > 1 : null,
+            'dates'              => static::get_event_dates( $event ),
         ];
 
         if ( ! empty( $event->location ) ) {
@@ -614,5 +657,60 @@ class ManualEvent {
         }
 
         return null;
+    }
+
+    /**
+     * Get event dates info
+     *
+     * @param object $event Event object.
+     *
+     * @return array
+     */
+    public static function get_event_dates( $event ) {
+        $dates = [];
+
+        if ( empty( $event->dates ) ) {
+            return $dates;
+        }
+
+        foreach ( $event->dates as $date ) {
+            $dates[] = [
+                'date' => self::compare_dates( $date['start'], $date['end'] ),
+            ];
+        }
+
+        return $dates;
+    }
+
+    /**
+     * Get event date
+     *
+     * @param string $start Event startdate.
+     * @param string $end Event enddate.
+     *
+     * @return string|null
+     */
+    public static function compare_dates( $start, $end ) {
+        if ( empty( $start ) ) {
+            return null;
+        }
+
+        $start_time  = static::get_as_datetime( $start );
+        $end_time    = static::get_as_datetime( $end );
+        $date_format = 'j.n.Y H.i';
+
+        if ( $start_time && $end_time && $start_time->diff( $end_time )->days >= 1 ) {
+            return sprintf(
+                '%s - %s',
+                $start_time->format( $date_format ),
+                $end_time->format( $date_format )
+            );
+        }
+
+        return sprintf(
+            '%s - %s',
+            $start_time->format( 'j.n.Y H.i' ),
+            $end_time->format( 'H.i' )
+        );
     }
 }

--- a/src/PostType/ManualEvent.php
+++ b/src/PostType/ManualEvent.php
@@ -465,7 +465,7 @@ class ManualEvent {
                 ->add_rule( $price_is_free->get_key(), '!=', '1' );
             $rule_group_is_virtual_event = ( new ConditionalLogicGroup() )
                 ->add_rule( $is_virtual_event->get_key(), '==', '1' );
-            $rule_group_is_not_recurring     = ( new ConditionalLogicGroup() )
+            $rule_group_is_not_recurring = ( new ConditionalLogicGroup() )
                 ->add_rule( $recurring_event->get_key(), '==', '0' );
             $rule_group_is_recurring     = ( new ConditionalLogicGroup() )
                 ->add_rule( $recurring_event->get_key(), '==', '1' );


### PR DESCRIPTION
Severa-ID: 2147
Severa-kuvaus: TMS-968 Manuaaliset tapahtumat: tapahtuman toistuvuus
Task: https://hiondigital.atlassian.net/browse/TMS-968

## Description
- Add recurring event fields to manual events
- Add recurring event logic to events component, combined event search & combined event listing

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
