### PR TITLE
Add a check for event dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning][semver].
 
 ## [Unreleased]
 
+- Add a check for event dates
+
 ## [1.3.2] - 2024-10-28
 
 - TMS-1075: Redipress 2 query fix

--- a/src/PostType/ManualEvent.php
+++ b/src/PostType/ManualEvent.php
@@ -603,7 +603,7 @@ class ManualEvent {
         }
 
         $start_time  = static::get_as_datetime( $event->start_datetime );
-        $end_time    = static::get_as_datetime( $event->end_datetime );
+        $end_time    = $event->end_datetime ? static::get_as_datetime( $event->end_datetime ) : null;
         $date_format = get_option( 'date_format' );
 
         if ( $start_time && $end_time && $start_time->diff( $end_time )->days >= 1 ) {
@@ -648,8 +648,8 @@ class ManualEvent {
             return null;
         }
 
-        $start_time  = static::get_as_datetime( $event->start_datetime );
-        $end_time    = static::get_as_datetime( $event->end_datetime );
+        $start_time  = ! empty( $event->start_datetime ) ? static::get_as_datetime( $event->start_datetime ) : '';
+        $end_time    = ! empty( $event->end_datetime ) ? static::get_as_datetime( $event->end_datetime ) : '';
         $time_format = 'H.i';
 
         if ( $start_time && $end_time ) {


### PR DESCRIPTION
Severa-ID: 2247
Severa-kuvaus: TMS-1025 Projektin ylläpito
Task: https://hiondigital.atlassian.net/browse/TMS-1025

## Description

Check if dates exist and remove end_date if it's not available. 
This is needed since the date-fields are not required for event-posts.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

